### PR TITLE
fix: support Elixir 1.20 strict compile

### DIFF
--- a/lib/jido_bedrock/storage/options.ex
+++ b/lib/jido_bedrock/storage/options.ex
@@ -47,15 +47,15 @@ defmodule Jido.Bedrock.Storage.Options do
 
   defp validate_repo(opts) do
     case Keyword.get(opts, :repo) do
+      nil ->
+        {:error, Error.config_error("Bedrock repo option is required", key: :repo, value: nil)}
+
       repo when is_atom(repo) ->
         if Code.ensure_loaded?(repo) do
           {:ok, repo}
         else
           {:error, Error.config_error("Bedrock repo module is not loaded", key: :repo, value: repo)}
         end
-
-      nil ->
-        {:error, Error.config_error("Bedrock repo option is required", key: :repo, value: nil)}
 
       other ->
         {:error,

--- a/lib/jido_bedrock/storage/threads.ex
+++ b/lib/jido_bedrock/storage/threads.ex
@@ -255,7 +255,7 @@ defmodule Jido.Bedrock.Storage.Threads do
   end
 
   defp validate_entry_inputs(entries) do
-    if Enum.all?(entries, &(is_map(&1) or match?(%Entry{}, &1))) do
+    if Enum.all?(entries, &is_map/1) do
       :ok
     else
       {:error,


### PR DESCRIPTION
## Summary
- Fix strict compiler warnings under Elixir 1.20 / OTP 29.
- Remove unused dependency lock entries where applicable.

## Verification
- mise exec erlang@29.0.1 elixir@1.20 -- mix compile --force --warnings-as-errors
- mise exec erlang@29.0.1 elixir@1.20 -- mix deps.unlock --check-unused
- mise exec erlang@29.0.1 elixir@1.20 -- mix format --check-formatted

Tests were not run; compile-only verification was requested.